### PR TITLE
Bump default SDK version constraint to >=0.12.6

### DIFF
--- a/cmd/check/check.go
+++ b/cmd/check/check.go
@@ -17,7 +17,7 @@ import (
 const (
 	CommandName             = "check"
 	goVersionConstraint     = ">=1.12"
-	SDKVersionConstraint    = ">=0.12"
+	SDKVersionConstraint    = ">=0.12.6"
 	terraformDependencyPath = "github.com/hashicorp/terraform"
 )
 


### PR DESCRIPTION
Providers should be on `hashicorp/terraform` v0.12.6 or above before migration.