### PR TITLE
vendor: Bump go-refs to latest revision

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/kmoe/go-list v0.0.1
 	github.com/mitchellh/cli v1.0.0
-	github.com/radeksimko/go-refs v0.0.0-20190614111518-1b15b5989e59
+	github.com/radeksimko/go-refs v0.0.0-20190823125319-880a3294a1a0
 	github.com/radeksimko/mod v0.0.0-20190807092412-93f771451dae
 )

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/posener/complete v1.1.1 h1:ccV59UEOTzVDnDUEFdT95ZzHVZ+5+158q8+SJb2QV5
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/radeksimko/go-refs v0.0.0-20190614111518-1b15b5989e59 h1:spSVb40pzPe4JoZLno+/E7Eq5Y0I21DFwdb32g/GN+4=
 github.com/radeksimko/go-refs v0.0.0-20190614111518-1b15b5989e59/go.mod h1:PYFsT0d8q5IGFGbiXhnVA5sQFXxPRNXf7CS/IL90rHY=
+github.com/radeksimko/go-refs v0.0.0-20190823125319-880a3294a1a0 h1:wgpRbINntHeCGMi2xqGfLN1havFatiACGZ7q+yKqJyw=
+github.com/radeksimko/go-refs v0.0.0-20190823125319-880a3294a1a0/go.mod h1:PYFsT0d8q5IGFGbiXhnVA5sQFXxPRNXf7CS/IL90rHY=
 github.com/radeksimko/mod v0.0.0-20190807092412-93f771451dae h1:I7Nl7r9VPplepwIlnEODWuesa2/CurhkwoQGCl4MZj8=
 github.com/radeksimko/mod v0.0.0-20190807092412-93f771451dae/go.mod h1:Q2IM8KSMt66rTOMAXh3BvCD8bYed5rx/ITZ/zNqYakc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/vendor/github.com/radeksimko/go-refs/parser/parser.go
+++ b/vendor/github.com/radeksimko/go-refs/parser/parser.go
@@ -55,6 +55,12 @@ func FindPackageReferences(f *ast.File, importPath string) ([]ast.Node, error) {
 				return true
 			}
 
+			if ident.Obj != nil {
+				// Avoid reporting references to local variables
+				// which may have the same name as package
+				return true
+			}
+
 			refs = append(refs, selector.Sel)
 		}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -23,7 +23,7 @@ github.com/posener/complete
 github.com/posener/complete/cmd/install
 github.com/posener/complete/cmd
 github.com/posener/complete/match
-# github.com/radeksimko/go-refs v0.0.0-20190614111518-1b15b5989e59
+# github.com/radeksimko/go-refs v0.0.0-20190823125319-880a3294a1a0
 github.com/radeksimko/go-refs/parser
 # github.com/radeksimko/mod v0.0.0-20190807092412-93f771451dae
 github.com/radeksimko/mod/modfile


### PR DESCRIPTION
This brings in a small patch which helps us avoid some false positives in reporting.