### PR TITLE
Add -mod=vendor to `go list` call

### DIFF
--- a/cmd/check/sdk_refs.go
+++ b/cmd/check/sdk_refs.go
@@ -78,7 +78,7 @@ type ProviderPackage struct {
 }
 
 func GoListPackageImports(providerPath string) (*ProviderImportDetails, error) {
-	packages, err := goList.GoList(providerPath, "./...")
+	packages, err := goList.GoList(providerPath, "./...", "-mod=vendor")
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-version v1.2.0
-	github.com/kmoe/go-list v0.0.1
+	github.com/kmoe/go-list v1.0.0
 	github.com/mitchellh/cli v1.0.0
 	github.com/radeksimko/go-refs v0.0.0-20190823125319-880a3294a1a0
 	github.com/radeksimko/mod v0.0.0-20190807092412-93f771451dae

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+d
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/kmoe/go-list v0.0.1 h1:hKNir14OZh/LBpw1EQNvy8LeCtlKidF00Bigly1h4ec=
 github.com/kmoe/go-list v0.0.1/go.mod h1:8bBhPyBnH3wJago3lVPOKvxA+KDmvAHFgLLmhpiQORE=
+github.com/kmoe/go-list v1.0.0 h1:MhzJwRRNiGE53t5y5LQxclnOvHiYiYtmO9QG9uMkbkQ=
+github.com/kmoe/go-list v1.0.0/go.mod h1:8bBhPyBnH3wJago3lVPOKvxA+KDmvAHFgLLmhpiQORE=
 github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/hashicorp/errwrap
 github.com/hashicorp/go-multierror
 # github.com/hashicorp/go-version v1.2.0
 github.com/hashicorp/go-version
-# github.com/kmoe/go-list v0.0.1
+# github.com/kmoe/go-list v1.0.0
 github.com/kmoe/go-list
 # github.com/mattn/go-colorable v0.0.9
 github.com/mattn/go-colorable


### PR DESCRIPTION
Prevent pulling all dependencies while checking for deprecated identifiers.

Bump `kmoe/go-list` to v1.0.0 to enable this additional argument.