### PR TITLE
bump sdk check to v0.12.7

### DIFF
--- a/cmd/check/check.go
+++ b/cmd/check/check.go
@@ -19,7 +19,7 @@ import (
 const (
 	CommandName             = "check"
 	goVersionConstraint     = ">=1.12"
-	sdkVersionConstraint    = ">=0.12.6"
+	sdkVersionConstraint    = ">=0.12.7"
 	terraformDependencyPath = "github.com/hashicorp/terraform"
 )
 


### PR DESCRIPTION
v0.12.7 should include new APIs for the version package work as well as the prepped removal of the config package, it's a good jumping off point.