### PR TITLE
cmd/migrate: Default to SDK v1.1.0

### DIFF
--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -27,7 +27,7 @@ const (
 	oldSDKImportPath  = "github.com/hashicorp/terraform"
 	newSDKImportPath  = "github.com/hashicorp/terraform-plugin-sdk"
 	newSDKPackagePath = "github.com/hashicorp/terraform-plugin-sdk"
-	defaultSDKVersion = "v1.0.0"
+	defaultSDKVersion = "v1.1.0"
 )
 
 var printConfig = printer.Config{


### PR DESCRIPTION
This is mainly to avoid potential gap in reporting (if not covered in provider code) as patched in https://github.com/hashicorp/terraform-plugin-sdk/pull/52