### PR TITLE
Bump default SDK version to v1.7.0

### DIFF
--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -27,7 +27,7 @@ const (
 	oldSDKImportPath  = "github.com/hashicorp/terraform"
 	newSDKImportPath  = "github.com/hashicorp/terraform-plugin-sdk"
 	newSDKPackagePath = "github.com/hashicorp/terraform-plugin-sdk"
-	defaultSDKVersion = "v1.1.0"
+	defaultSDKVersion = "v1.7.0"
 )
 
 var printConfig = printer.Config{


### PR DESCRIPTION
Migrator will now migrate providers to SDK v1.7.0, the latest version as of this PR. After merging this I'll tag v1.1.0 of the migrator tool, so the latest version of the tool is installed with `go install`.