### PR TITLE
Add SDKv2 upgrade command

### DIFF
--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -47,7 +47,7 @@ func (c *command) Help() string {
 	return `Usage: tf-sdk-migrator migrate [--help] [--sdk-version SDK_VERSION] [--force] [IMPORT_PATH]
 
   Migrates the Terraform provider at PATH to the new Terraform provider
-  SDK, defaulting to version ` + defaultSDKVersion + `.
+  SDK, defaulting to the git reference ` + defaultSDKVersion + `.
 
   IMPORT_PATH is resolved relative to $GOPATH/src/IMPORT_PATH. If it is not supplied,
   it is assumed that the current working directory contains a Terraform provider.

--- a/cmd/v2upgrade/v2upgrade.go
+++ b/cmd/v2upgrade/v2upgrade.go
@@ -46,7 +46,7 @@ func (c *command) Help() string {
 	return `Usage: tf-sdk-migrator v2upgrade [--help] [--sdk-version SDK_VERSION] [IMPORT_PATH]
 
   Upgrades the Terraform provider to major version 2 of the Terraform
-  provider SDK, defaulting to version ` + defaultVersion + `.
+  provider SDK, defaulting to the git reference ` + defaultVersion + `.
 
   Rewrites import paths and go.mod. No backup is made before files are
   overwritten.

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/logutils"
 	"github.com/hashicorp/tf-sdk-migrator/cmd/check"
 	"github.com/hashicorp/tf-sdk-migrator/cmd/migrate"
+	"github.com/hashicorp/tf-sdk-migrator/cmd/v2upgrade"
 	"github.com/mitchellh/cli"
 )
 
@@ -33,8 +34,9 @@ func main() {
 	c := cli.NewCLI("tf-sdk-migrator", "0.1.0")
 	c.Args = os.Args[1:]
 	c.Commands = map[string]cli.CommandFactory{
-		check.CommandName:   check.CommandFactory(ui),
-		migrate.CommandName: migrate.CommandFactory(ui),
+		check.CommandName:     check.CommandFactory(ui),
+		migrate.CommandName:   migrate.CommandFactory(ui),
+		v2upgrade.CommandName: v2upgrade.CommandFactory(ui),
 	}
 
 	exitStatus, err := c.Run()

--- a/util/util.go
+++ b/util/util.go
@@ -127,7 +127,10 @@ func RewriteGoMod(providerPath string, sdkVersion string, oldPackagePath string,
 }
 
 func RewriteImportedPackageImports(filePath string, stringToReplace string, replacement string) error {
-	// TODO: check file exists so ParseFile doesn't panic
+	if _, err := os.Stat(filePath); err != nil {
+		return err
+	}
+
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
 	if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -93,7 +93,7 @@ func GetProviderPath(providerRepoName string) (string, error) {
 }
 
 func RewriteGoMod(providerPath string, sdkVersion string, oldPackagePath string, newPackagePath string) error {
-	goModPath := providerPath + "/go.mod"
+	goModPath := filepath.Join(providerPath, "go.mod")
 
 	input, err := ioutil.ReadFile(goModPath)
 	if err != nil {


### PR DESCRIPTION
Partial implementation of #38 

Add a command to upgrade the major version of the SDK to v2. Defaults to the HEAD of master at the moment as there is no release candidate yet.

Currently, all it does is rewrite `go.mod` and import paths in all files when you run `tf-sdk-migrator v2upgrade`. Type rewrites and other breaking change upgrades that can be done deterministically will be added later.

```
Usage: tf-sdk-migrator v2upgrade [--help] [--sdk-version SDK_VERSION] [IMPORT_PATH]

  Upgrades the Terraform provider to major version 2 of the Terraform
  provider SDK, defaulting to version master.

  Rewrites import paths and go.mod. No backup is made before files are
  overwritten.

  IMPORT_PATH is resolved relative to $GOPATH/src/IMPORT_PATH. If it is not supplied,
  it is assumed that the current working directory contains a Terraform provider.

  Optionally, an SDK_VERSION can be passed, which is parsed as a Go module
  release version. For example: v2.0.1, latest, master.

Example:
  tf-sdk-migrator v2upgrade --sdk-version v2.0.0-rc.1 github.com/terraform-providers/terraform-provider-local
```