### PR TITLE
Bump default SDKv2 version to v2.0.3

### DIFF
--- a/cmd/v2upgrade/v2upgrade.go
+++ b/cmd/v2upgrade/v2upgrade.go
@@ -16,7 +16,7 @@ const (
 	CommandName    = "v2upgrade"
 	oldPackagePath = "github.com/hashicorp/terraform-plugin-sdk"
 	newPackagePath = "github.com/hashicorp/terraform-plugin-sdk/v2"
-	defaultVersion = "master"
+	defaultVersion = "v2.0.3"
 )
 
 var printConfig = printer.Config{


### PR DESCRIPTION
Now that SDKv2 is released and stable, install v2.0.3 by default when running `tf-sdk-migrator v2upgrade`.