### PR TITLE
Use Dockerhub Mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ version: 2.1
 jobs:
   "docker-go112 build":
     docker:
-      - image: circleci/golang:1.12
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.12
     steps:
       - checkout
       - run: go build -mod=vendor ./...
   "docker-go112 test":
     docker:
-      - image: circleci/golang:1.12
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.12
     parameters:
       test_results:
         type: string
@@ -29,13 +29,13 @@ jobs:
           path: << parameters.test_results >>
   "docker-go112 vet":
     docker:
-      - image: circleci/golang:1.12
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.12
     steps:
       - checkout
       - run: go vet -mod=vendor ./...
   "docker-go112 gofmt":
     docker:
-      - image: circleci/golang:1.12
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.12
     steps:
       - checkout
       - run: ./scripts/gofmtcheck.sh


### PR DESCRIPTION
Dockerhub is going to rate limit unauthenticated pulls.

Use internal mirror for CI and Dockerfiles built in CI.